### PR TITLE
Remove unnecessary files from npm package

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,8 @@
 language: node_js
 node_js:
-  - 0.6
-  - 0.8
+  - "0.12"
+  - "0.10"
+  - "0.8"
+  - iojs
+before_install:
+  - npm install -g npm@~1.4.6

--- a/package.json
+++ b/package.json
@@ -3,6 +3,11 @@
   "version": "0.0.5",
   "description": "A faster Node.js alternative to Array.prototype.slice.call(arguments)",
   "main": "index.js",
+  "files": [
+    "LICENSE",
+    "README.md",
+    "index.js"
+  ],
   "scripts": {
     "test": "make test"
   },


### PR DESCRIPTION
This adds a files property to the package.json that whitelists what files you want in the published npm package. This reduces unnecessary files installed on the machine when the package installed. I added support in .travis.yml for node.js  v0.10/v0.12 and for iojs as well.