### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-#sliced
+# sliced
 ==========
 
 A faster alternative to `[].slice.call(arguments)`.
@@ -39,7 +39,7 @@ Example output from [benchmark.js](https://github.com/bestiejs/benchmark.js)
 
 _Benchmark  [source](https://github.com/aheckmann/sliced/blob/master/bench.js)._
 
-##Usage
+## Usage
 
 `sliced` accepts the same arguments as `Array#slice` so you can easily swap it out.
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
